### PR TITLE
updates to showpage

### DIFF
--- a/app/assets/stylesheets/components/_description_card.scss
+++ b/app/assets/stylesheets/components/_description_card.scss
@@ -1,20 +1,16 @@
 .description-card {
   overflow: hidden;
   padding: 16px;
-  height: 193px;
   background: white;
   color: #F49D37;
   border-radius: 9px;
   align-items: center;
-  overflow: scroll;
 }
-
 
 .description-card h2 {
   font-size: 16px;
   font-weight: bold;
   margin: 0;
-  padding-right: 50px;
 }
 
 .description-card p {
@@ -24,4 +20,13 @@
   margin-bottom: 0;
   margin-top: 8px;
   color: #6A6A6A;
+}
+
+.icons_card {
+  padding: 8px;
+  margin-bottom: 4px;
+  background: white;
+  color: #F49D37;
+  border-radius: 9px;
+  text-align: right;
 }

--- a/app/assets/stylesheets/components/_show_container.scss
+++ b/app/assets/stylesheets/components/_show_container.scss
@@ -2,3 +2,6 @@
   padding-top: 15px;
   justify-content: center;
 }
+
+
+

--- a/app/views/episodes/show.html.erb
+++ b/app/views/episodes/show.html.erb
@@ -1,31 +1,28 @@
 <div class="container">
 
   <%= render "shared/spotifywidget", episode: @episode %>
-<br>
-<br>
-  <div class="description-card">
 
-      <div class="d-flex justify-content-between">
-        <h2><b><%= @episode.title %></b></h2>
-
-        <% if user_signed_in? %>
-          <div class="show-button">
-            <%= link_to like_episode_path(@episode), class: "like", method: :put do %>
-              <i class="far fa-thumbs-up"></i>
-              <%= @episode.votes_for.size + @episode.upvotes %>
-            <% end %>
-            <i class="fas fa-headphones"></i>
-            <%= @episode.listens %>
-          </div>
-        <% else %>
+  <div class="icons_card">
+    <% if user_signed_in? %>
+        <div class="show-button">
+          <%= link_to like_episode_path(@episode), class: "like", method: :put do %>
+            <i class="far fa-thumbs-up"><%= @episode.votes_for.size + @episode.upvotes %></i>
+          <% end %>
+            <i class="fas fa-headphones"><%= @episode.listens %></i>
+        </div>
+    <% else %>
         <div class="show-button">
           <i class="far fa-thumbs-up like"></i>
-          <%= @episode.votes_for.size + @episode.upvotes %>
+            <%= @episode.votes_for.size + @episode.upvotes %>
           <i class="fas fa-headphones"></i>
-          <%= @episode.listens %>
+            <%= @episode.listens %>
         </div>
-        <% end %>
-      </div>
+    <% end %>
+  </div>
+
+  <div class="description-card">
+    <h2><b><%= @episode.title %></b></h2>
     <p><%= @episode.summary %></p>
   </div>
+
 </div>


### PR DESCRIPTION
Moved upvote and headphone icons to their own div and in their own card just below the spotify widget.

scroll function on podcast description disabled for UX ease

height on container taken off to accomodate for all description lengths of podcast episodes 