### PR TITLE
showpage button

### DIFF
--- a/app/views/episodes/show.html.erb
+++ b/app/views/episodes/show.html.erb
@@ -6,16 +6,16 @@
     <% if user_signed_in? %>
         <div class="show-button">
           <%= link_to like_episode_path(@episode), class: "like", method: :put do %>
-            <i class="far fa-thumbs-up"><%= @episode.votes_for.size + @episode.upvotes %></i>
+            <i class="far fa-thumbs-up"></i><%= @episode.votes_for.size + @episode.upvotes %>
           <% end %>
-            <i class="fas fa-headphones"><%= @episode.listens %></i>
+            <i class="fas fa-headphones"></i><%= @episode.listens %>
         </div>
     <% else %>
         <div class="show-button">
           <i class="far fa-thumbs-up like"></i>
-            <%= @episode.votes_for.size + @episode.upvotes %>
+          <%= @episode.votes_for.size + @episode.upvotes %>
           <i class="fas fa-headphones"></i>
-            <%= @episode.listens %>
+          <%= @episode.listens %>
         </div>
     <% end %>
   </div>


### PR DESCRIPTION
Fixed a formatting error with the upvotes and headphones button when you logged in

The formatting of the upvotes and headphones was changed between the pages when a user was logged in to when a user wasn't. This has now been fixed