### PR TITLE
removed two links on homepage carousel

### DIFF
--- a/app/views/pages/_carousel.html.erb
+++ b/app/views/pages/_carousel.html.erb
@@ -1,15 +1,11 @@
   <div id="carousel">
 
     <div class="hideLeft">
-      <%= link_to episode_path(Episode.find_by(title: "Ep. 95 - Chicken Leg, Chicken Wing")) do %>
         <img src="https://thumborcdn.acast.com/46gcVg9exHSnTdmTYla0qTxVcKM=/3000x3000/https://mediacdn.acast.com/assets/a3289f5e-b832-4883-8634-f8e1b63d2506/cover-image-k262ujt2-crest_1500x1500.png">
-      <% end %>
     </div>
 
     <div class="prevLeftSecond">
-      <%= link_to episode_path(Episode.find_by(title: "S2E2 - 'Amsterdammmm'")) do %>
         <img src="https://upload.wikimedia.org/wikipedia/en/f/f8/My_Dad_Wrote_a_Porno_logo.jpg">
-      <% end %>
     </div>
 
     <div class="prev">


### PR DESCRIPTION
Removed two of the links in the carousel on the homepage and just left the selected option as clickable (House of Rugby)